### PR TITLE
feat: allow arbitrary payloads

### DIFF
--- a/lib/help/check_footer.js
+++ b/lib/help/check_footer.js
@@ -14,7 +14,7 @@ module.exports = function checkFooter (footer) {
   }
 
   if (typeof footer !== 'string') {
-    throw new TypeError('options.footer must be a string, Buffer or a plain object')
+    throw new TypeError('options.footer must be a string, Buffer, or a plain object')
   }
 
   return Buffer.from(footer, 'utf8')

--- a/lib/help/check_payload.js
+++ b/lib/help/check_payload.js
@@ -1,9 +1,20 @@
+const applyOptions = require('./apply_options')
 const isObject = require('./is_object')
 const deepClone = payload => JSON.parse(JSON.stringify(payload))
 
-module.exports = (payload) => {
-  if (!isObject(payload)) {
-    throw new TypeError('payload must be a plain object')
+module.exports = (payload, options) => {
+  if (Buffer.isBuffer(payload)) {
+    if (Object.keys(options).length !== 0) {
+      throw new TypeError('options cannot contain claims when payload is a Buffer')
+    }
+
+    return payload
   }
-  return deepClone(payload)
+  if (!isObject(payload)) {
+    throw new TypeError('payload must be a Buffer or a plain object')
+  }
+
+  payload = deepClone(payload)
+  payload = applyOptions(options, payload)
+  return Buffer.from(JSON.stringify(payload), 'utf-8')
 }

--- a/lib/help/sign.js
+++ b/lib/help/sign.js
@@ -3,8 +3,7 @@ const { sign } = require('./crypto_worker')
 const pae = require('./pae')
 const pack = require('./pack')
 
-module.exports = async function signPaseto (h, payload, f, alg, key, expectedSigLength) {
-  const m = Buffer.from(JSON.stringify(payload), 'utf8')
+module.exports = async function signPaseto (h, m, f, alg, key, expectedSigLength) {
   const m2 = pae(h, m, f)
   const sig = await sign(alg, m2, key)
 

--- a/lib/help/verify.js
+++ b/lib/help/verify.js
@@ -3,7 +3,6 @@ const { PasetoInvalid, PasetoVerificationFailed } = require('../errors')
 const { decode } = require('./base64url')
 const { verify } = require('./crypto_worker')
 const pae = require('./pae')
-const parse = require('./parse_paseto_payload')
 
 module.exports = async function verifyPaseto (h, token, alg, sigLength, key) {
   if (typeof token !== 'string') {
@@ -40,7 +39,7 @@ module.exports = async function verifyPaseto (h, token, alg, sigLength, key) {
   }
 
   return {
-    payload: parse(m),
+    m,
     footer: f.length ? f : undefined
   }
 }

--- a/lib/v1/decrypt.js
+++ b/lib/v1/decrypt.js
@@ -7,7 +7,7 @@ const parse = require('../help/parse_paseto_payload')
 
 const h = 'v1.local.'
 
-module.exports = async function v1Decrypt (token, key, { complete = false, ...options } = {}) {
+module.exports = async function v1Decrypt (token, key, { complete = false, buffer = false, ...options } = {}) {
   if (typeof token !== 'string') {
     throw new TypeError(`token must be a string, got: ${typeof token}`)
   }
@@ -27,12 +27,23 @@ module.exports = async function v1Decrypt (token, key, { complete = false, ...op
   const raw = decode(b64)
   const k = key.export()
 
-  let payload = await decrypt(raw, f, k)
-  if (!payload) {
+  const m = await decrypt(raw, f, k)
+  if (!m) {
     throw new PasetoDecryptionFailed('decryption failed')
   }
 
-  payload = parse(payload)
+  if (buffer) {
+    if (Object.keys(options).length !== 0) {
+      throw new TypeError('options cannot contain claims when options.buffer is true')
+    }
+    if (complete) {
+      return { payload: m, footer: f.length ? f : undefined, version: 'v2', purpose: 'local' }
+    }
+
+    return m
+  }
+
+  const payload = parse(m)
 
   assertPayload(options, payload)
 

--- a/lib/v1/encrypt.js
+++ b/lib/v1/encrypt.js
@@ -1,4 +1,3 @@
-const applyOptions = require('../help/apply_options')
 const checkFooter = require('../help/check_footer')
 const checkKey = require('../help/symmetric_key_check').bind(undefined, 'v1.local')
 const checkPayload = require('../help/check_payload')
@@ -6,12 +5,10 @@ const randomBytes = require('../help/random_bytes')
 const { 'aes-256-ctr-hmac-sha-384-encrypt': encrypt } = require('../help/crypto_worker')
 
 module.exports = async function v1Encrypt (payload, key, { footer, nonce, ...options } = {}) {
-  payload = checkPayload(payload)
+  const m = checkPayload(payload, options)
   key = checkKey(key)
   const f = checkFooter(footer)
-  payload = applyOptions(options, payload)
 
-  const m = Buffer.from(JSON.stringify(payload), 'utf8')
   const k = key.export()
 
   if ((nonce && process.env.NODE_ENV !== 'test') || !nonce) {

--- a/lib/v1/sign.js
+++ b/lib/v1/sign.js
@@ -7,7 +7,6 @@ const {
   KeyObject
 } = require('crypto')
 
-const applyOptions = require('../help/apply_options')
 const checkFooter = require('../help/check_footer')
 const checkPayload = require('../help/check_payload')
 const sign = require('../help/sign')
@@ -25,9 +24,8 @@ function checkKey (key) {
 }
 
 module.exports = async function v1Sign (payload, key, { footer, ...options } = {}) {
-  payload = checkPayload(payload)
+  const m = checkPayload(payload, options)
   const f = checkFooter(footer)
-  payload = applyOptions(options, payload)
   key = checkKey(key)
-  return sign('v1.public.', payload, f, 'sha384', { key, padding, saltLength }, 256)
+  return sign('v1.public.', m, f, 'sha384', { key, padding, saltLength }, 256)
 }

--- a/lib/v1/verify.js
+++ b/lib/v1/verify.js
@@ -8,6 +8,7 @@ const {
 } = require('crypto')
 
 const assertPayload = require('../help/assert_payload')
+const parse = require('../help/parse_paseto_payload')
 const verify = require('../help/verify')
 
 function checkKey (key) {
@@ -22,11 +23,20 @@ function checkKey (key) {
   return key
 }
 
-module.exports = async function v1Verify (token, key, { complete = false, ...options } = {}) {
+module.exports = async function v1Verify (token, key, { complete = false, buffer = false, ...options } = {}) {
   key = checkKey(key)
 
-  const { payload, footer } = await verify('v1.public.', token, 'sha384', 256, { key, padding, saltLength })
+  const { m, footer } = await verify('v1.public.', token, 'sha384', 256, { key, padding, saltLength })
 
+  if (buffer) {
+    if (complete) {
+      return { payload: m, footer, version: 'v2', purpose: 'public' }
+    }
+
+    return m
+  }
+
+  const payload = parse(m)
   assertPayload(options, payload)
 
   if (complete) {

--- a/lib/v2/sign.js
+++ b/lib/v2/sign.js
@@ -3,7 +3,6 @@ const {
   KeyObject
 } = require('crypto')
 
-const applyOptions = require('../help/apply_options')
 const checkFooter = require('../help/check_footer')
 const checkPayload = require('../help/check_payload')
 const sign = require('../help/sign')
@@ -21,9 +20,8 @@ function checkKey (key) {
 }
 
 module.exports = async function v2Sign (payload, key, { footer, ...options } = {}) {
-  payload = checkPayload(payload)
-  const f = checkFooter(footer)
-  payload = applyOptions(options, payload)
+  const m = checkPayload(payload, options)
   key = checkKey(key)
-  return sign('v2.public.', payload, f, undefined, key, 64)
+  const f = checkFooter(footer)
+  return sign('v2.public.', m, f, undefined, key, 64)
 }

--- a/lib/v2/verify.js
+++ b/lib/v2/verify.js
@@ -4,6 +4,7 @@ const {
 } = require('crypto')
 
 const assertPayload = require('../help/assert_payload')
+const parse = require('../help/parse_paseto_payload')
 const verify = require('../help/verify')
 
 function checkKey (key) {
@@ -18,11 +19,20 @@ function checkKey (key) {
   return key
 }
 
-module.exports = async function v2Verify (token, key, { complete = false, ...options } = {}) {
+module.exports = async function v2Verify (token, key, { complete = false, buffer = false, ...options } = {}) {
   key = checkKey(key)
 
-  const { payload, footer } = await verify('v2.public.', token, undefined, 64, key)
+  const { m, footer } = await verify('v2.public.', token, undefined, 64, key)
 
+  if (buffer) {
+    if (complete) {
+      return { payload: m, footer, version: 'v2', purpose: 'public' }
+    }
+
+    return m
+  }
+
+  const payload = parse(m)
   assertPayload(options, payload)
 
   if (complete) {

--- a/test/check_footer.test.js
+++ b/test/check_footer.test.js
@@ -5,6 +5,6 @@ const checkFooter = require('../lib/help/check_footer')
 test('when not a buffer, string or an object', t => {
   t.throws(
     () => checkFooter(1),
-    { instanceOf: TypeError, message: 'options.footer must be a string, Buffer or a plain object' }
+    { instanceOf: TypeError, message: 'options.footer must be a string, Buffer, or a plain object' }
   )
 })

--- a/test/public.test.js
+++ b/test/public.test.js
@@ -124,3 +124,43 @@ test('v1 doesnt validate v2', async t => {
     { instanceOf: errors.PasetoInvalid, code: 'ERR_PASETO_INVALID', message: 'token is not a v1.public token' }
   )
 })
+
+test('V1.validate needs a JSON payload', async t => {
+  const k = await V1.generateKey('public')
+
+  const token = await V1.sign(Buffer.from('test'), k)
+
+  return t.throwsAsync(
+    V1.verify(token, k),
+    { instanceOf: errors.PasetoInvalid, code: 'ERR_PASETO_INVALID', message: 'All PASETO payloads MUST be a JSON object' }
+  )
+})
+
+test('V2.validate needs a JSON payload', async t => {
+  const k = await V2.generateKey('public')
+
+  const token = await V2.sign(Buffer.from('test'), k)
+
+  return t.throwsAsync(
+    V2.verify(token, k),
+    { instanceOf: errors.PasetoInvalid, code: 'ERR_PASETO_INVALID', message: 'All PASETO payloads MUST be a JSON object' }
+  )
+})
+
+test('V1.sign can use Buffer as payload', async t => {
+  const k = await V1.generateKey('public')
+
+  const token = await V1.sign(Buffer.from('test'), k)
+
+  const payload = await V1.verify(token, k, { buffer: true })
+  t.true(Buffer.isBuffer(payload))
+})
+
+test('V2.sign can use Buffer as payload', async t => {
+  const k = await V2.generateKey('public')
+
+  const token = await V2.sign(Buffer.from('test'), k)
+
+  const payload = await V2.verify(token, k, { buffer: true })
+  t.true(Buffer.isBuffer(payload))
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -55,6 +55,11 @@ export interface ConsumeOptions<TComplete extends boolean> {
      */
     complete?: TComplete;
     /**
+     * When false the parsed payload is returned, otherwise the raw payload (as a Buffer) will be returned
+     * @default false
+     */
+    buffer?: false;
+    /**
      * When true will not be validating the "exp" claim value to be in the future from now
      * @default false
      */
@@ -96,11 +101,46 @@ export interface CompleteResult {
     version: string;
 }
 
+export interface ConsumeOptionsBuffer<TComplete extends boolean> {
+    /**
+     * When false only the parsed payload is returned, otherwise an object with a parsed payload and footer (as a Buffer) will be returned
+     * @default false
+     */
+    complete?: TComplete;
+    /**
+     * When false the parsed payload is returned, otherwise the raw payload (as a Buffer) will be returned
+     * @default true
+     */
+    buffer: true;
+}
+
+export interface CompleteResultBuffer {
+    /** PASETO footer */
+    footer?: Buffer;
+    /** PASETO payload */
+    payload: Buffer;
+    /** PASETO purpose */
+    purpose: 'local' | 'public';
+    /** Protocol version */
+    version: string;
+}
+
 export interface DecodeResult {
     /** PASETO footer */
     footer?: Buffer;
     /** PASETO Payload claims */
     payload?: object;
+    /** PASETO purpose */
+    purpose: 'local' | 'public';
+    /** Protocol version */
+    version: string;
+}
+
+export interface DecodeResultBuffer {
+    /** PASETO footer */
+    footer?: Buffer;
+    /** PASETO payload */
+    payload?: Buffer;
     /** PASETO purpose */
     purpose: 'local' | 'public';
     /** Protocol version */
@@ -132,8 +172,8 @@ export namespace V1 {
      * })()
      */
     function sign(
-        /** PASETO Payload claims */
-        payload: object,
+        /** PASETO Payload claims or payload */
+        payload: object | Buffer,
         /** The key to sign with. Alternatively any input that works for `crypto.createPrivateKey` */
         key: KeyObject | PrivateKeyInput,
         options?: ProduceOptions,
@@ -160,8 +200,8 @@ export namespace V1 {
      * })()
      */
     function encrypt(
-        /** PASETO Payload claims */
-        payload: object,
+        /** PASETO Payload claims or payload */
+        payload: object | Buffer,
         /** The secret key to encrypt with. Alternatively any input that works for `crypto.createSecretKey` */
         key: KeyObject | Buffer,
         options?: ProduceOptions,
@@ -206,6 +246,20 @@ export namespace V1 {
         key: KeyObject | PublicKeyInput,
         options?: ConsumeOptions<true>,
     ): Promise<CompleteResult>;
+    function verify(
+        /** PASETO to verify */
+        token: string,
+        /** The key to verify with. Alternatively any input that works for `crypto.createPublicKey` */
+        key: KeyObject | PublicKeyInput,
+        options?: ConsumeOptionsBuffer<false>,
+    ): Promise<Buffer>;
+    function verify(
+        /** PASETO to verify */
+        token: string,
+        /** The key to verify with. Alternatively any input that works for `crypto.createPublicKey` */
+        key: KeyObject | PublicKeyInput,
+        options?: ConsumeOptionsBuffer<true>,
+    ): Promise<CompleteResultBuffer>;
 
     /**
      * Decrypts and validates the claims of a PASETO
@@ -246,6 +300,20 @@ export namespace V1 {
         key: KeyObject | Buffer,
         options?: ConsumeOptions<true>,
     ): Promise<CompleteResult>;
+    function decrypt(
+        /** PASETO to decrypt and validate */
+        token: string,
+        /** The secret key to decrypt with. Alternatively any input that works for `crypto.createSecretKey` */
+        key: KeyObject | Buffer,
+        options?: ConsumeOptionsBuffer<false>,
+    ): Promise<Buffer>;
+    function decrypt(
+        /** PASETO to decrypt and validate */
+        token: string,
+        /** The secret key to decrypt with. Alternatively any input that works for `crypto.createSecretKey` */
+        key: KeyObject | Buffer,
+        options?: ConsumeOptionsBuffer<true>,
+    ): Promise<CompleteResultBuffer>;
 
     /** Generates a new secret or private key for a given purpose */
     function generateKey(
@@ -277,8 +345,8 @@ export namespace V2 {
      * })()
      */
     function sign(
-        /** PASETO Payload claims */
-        payload: object,
+        /** PASETO Payload claims or payload */
+        payload: object | Buffer,
         /** The key to sign with. Alternatively any input that works for `crypto.createPrivateKey` */
         key: KeyObject | PrivateKeyInput,
         options?: ProduceOptions,
@@ -323,6 +391,20 @@ export namespace V2 {
         key: KeyObject | PublicKeyInput,
         options?: ConsumeOptions<true>,
     ): Promise<CompleteResult>;
+    function verify(
+        /** PASETO to verify */
+        token: string,
+        /** The key to verify with. Alternatively any input that works for `crypto.createPublicKey` */
+        key: KeyObject | PublicKeyInput,
+        options?: ConsumeOptionsBuffer<false>,
+    ): Promise<Buffer>;
+    function verify(
+        /** PASETO to verify */
+        token: string,
+        /** The key to verify with. Alternatively any input that works for `crypto.createPublicKey` */
+        key: KeyObject | PublicKeyInput,
+        options?: ConsumeOptionsBuffer<true>,
+    ): Promise<CompleteResultBuffer>;
 
     /** Generates a new secret or private key for a given purpose */
     function generateKey(


### PR DESCRIPTION
The reference PHP implementation[1] allows "to store arbitrary binary
data in a PASETO, by invoking the Protocol classes directly". This
change adds support for the V1.{sign,encrypt}/V2.sign functions to be
able to receive Buffers as the payload. It also adds a new option (`{
buffer: true }`) to the V1.{verify,decrypt}/V2.verify functions so that
they return a Buffer instead of a parsed token, for symmetry.

1: https://github.com/paragonie/paseto/tree/master/docs/02-PHP-Library#using-the-protocol-directly